### PR TITLE
Makefile: support macOS on arm64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,10 @@ ifeq ($(sys),Darwinppc64)
  system=mac
  f90compiler=gfortran
 endif
+ifeq ($(sys),Darwinarm64)
+ system=maci
+ f90compiler=gfortran
+endif
 ifeq ($(sys),aix)
  system=aix
  f90compiler=xlf90


### PR DESCRIPTION
Looks like we can use Intel template for arm64 as well.

```
--->  Applying patches to mcmcf90
--->  Applying patch-dynlib.diff
Executing:  cd "/opt/local/var/macports/build/_opt_svacchanda_SonomaPorts_math_mcmcf90/mcmcf90/work/mcmcf90-67d6078137b7bdd6ed8ba84440ca99237301fe86" && /usr/bin/patch -p0 < '/opt/svacchanda/SonomaPorts/math/mcmcf90/files/patch-dynlib.diff'
patching file Makefile
--->  Applying patch-arm64.diff
Executing:  cd "/opt/local/var/macports/build/_opt_svacchanda_SonomaPorts_math_mcmcf90/mcmcf90/work/mcmcf90-67d6078137b7bdd6ed8ba84440ca99237301fe86" && /usr/bin/patch -p0 < '/opt/svacchanda/SonomaPorts/math/mcmcf90/files/patch-arm64.diff'
patching file Makefile
--->  Patching mac.mk: s|F90=gfortran|F90=/opt/local/bin/gfortran-mp-14|g
--->  Patching mac.mk: s|F77=gfortran|F77=/opt/local/bin/gfortran-mp-14|g
--->  Patching maci.mk: s|F90=gfortran|F90=/opt/local/bin/gfortran-mp-14|g
--->  Patching maci.mk: s|F77=gfortran|F77=/opt/local/bin/gfortran-mp-14|g
--->  Patching Makefile: s|@PREFIX@|/opt/local|
--->  Configuring mcmcf90
--->  Building mcmcf90
Executing:  cd "/opt/local/var/macports/build/_opt_svacchanda_SonomaPorts_math_mcmcf90/mcmcf90/work/mcmcf90-67d6078137b7bdd6ed8ba84440ca99237301fe86" && /usr/bin/make -w all CC="/opt/local/var/macports/build/_opt_svacchanda_SonomaPorts_math_mcmcf90/mcmcf90/work/compwrap/cc/usr/bin/clang" CXX="/opt/local/var/macports/build/_opt_svacchanda_SonomaPorts_math_mcmcf90/mcmcf90/work/compwrap/cxx/usr/bin/clang++" OBJC="/opt/local/var/macports/build/_opt_svacchanda_SonomaPorts_math_mcmcf90/mcmcf90/work/compwrap/objc/usr/bin/clang" OBJCXX="/opt/local/var/macports/build/_opt_svacchanda_SonomaPorts_math_mcmcf90/mcmcf90/work/compwrap/objcxx/usr/bin/clang++" FC="/opt/local/var/macports/build/_opt_svacchanda_SonomaPorts_math_mcmcf90/mcmcf90/work/compwrap/fc/opt/local/bin/gfortran-mp-14" F90="/opt/local/var/macports/build/_opt_svacchanda_SonomaPorts_math_mcmcf90/mcmcf90/work/compwrap/f90/opt/local/bin/gfortran-mp-14" INSTALL="/usr/bin/install -c" 
make: Entering directory `/opt/local/var/macports/build/_opt_svacchanda_SonomaPorts_math_mcmcf90/mcmcf90/work/mcmcf90-67d6078137b7bdd6ed8ba84440ca99237301fe86'
/opt/local/bin/gfortran-mp-14 -DGFORTRAN -frecord-marker=4 -fconvert=little-endian -fpic -O3 -ftree-vectorize -mtune=native  -c dchud.f
/opt/local/bin/gfortran-mp-14 -DGFORTRAN -frecord-marker=4 -fconvert=little-endian -fpic -O3 -ftree-vectorize -mtune=native  -c dchdd.f
/opt/local/var/macports/build/_opt_svacchanda_SonomaPorts_math_mcmcf90/mcmcf90/work/compwrap/f90/opt/local/bin/gfortran-mp-14 -DGFORTRAN -frecord-marker=4 -fconvert=little-endian -fpic  -O3 -ftree-vectorize -mtune=native  -c mcmcprec.F90
/opt/local/var/macports/build/_opt_svacchanda_SonomaPorts_math_mcmcf90/mcmcf90/work/compwrap/f90/opt/local/bin/gfortran-mp-14 -DGFORTRAN -frecord-marker=4 -fconvert=little-endian -fpic  -O3 -ftree-vectorize -mtune=native  -c mcmcinit.F90
/opt/local/var/macports/build/_opt_svacchanda_SonomaPorts_math_mcmcf90/mcmcf90/work/compwrap/f90/opt/local/bin/gfortran-mp-14 -DGFORTRAN -frecord-marker=4 -fconvert=little-endian -fpic  -O3 -ftree-vectorize -mtune=native  -c mcmcrand.F90
/opt/local/var/macports/build/_opt_svacchanda_SonomaPorts_math_mcmcf90/mcmcf90/work/compwrap/f90/opt/local/bin/gfortran-mp-14 -DGFORTRAN -frecord-marker=4 -fconvert=little-endian -fpic  -O3 -ftree-vectorize -mtune=native  -c matfiles.F90
/opt/local/var/macports/build/_opt_svacchanda_SonomaPorts_math_mcmcf90/mcmcf90/work/compwrap/f90/opt/local/bin/gfortran-mp-14 -DGFORTRAN -frecord-marker=4 -fconvert=little-endian -fpic  -O3 -ftree-vectorize -mtune=native  -c matutils.F90
/opt/local/var/macports/build/_opt_svacchanda_SonomaPorts_math_mcmcf90/mcmcf90/work/compwrap/f90/opt/local/bin/gfortran-mp-14 -DGFORTRAN -frecord-marker=4 -fconvert=little-endian -fpic  -O3 -ftree-vectorize -mtune=native  -c mcmcrun1.F90
/opt/local/var/macports/build/_opt_svacchanda_SonomaPorts_math_mcmcf90/mcmcf90/work/compwrap/f90/opt/local/bin/gfortran-mp-14 -DGFORTRAN -frecord-marker=4 -fconvert=little-endian -fpic  -O3 -ftree-vectorize -mtune=native  -c mcmc.F90
/opt/local/var/macports/build/_opt_svacchanda_SonomaPorts_math_mcmcf90/mcmcf90/work/compwrap/f90/opt/local/bin/gfortran-mp-14 -DGFORTRAN -frecord-marker=4 -fconvert=little-endian -fpic  -O3 -ftree-vectorize -mtune=native  -c priorfun.f90
/opt/local/var/macports/build/_opt_svacchanda_SonomaPorts_math_mcmcf90/mcmcf90/work/compwrap/f90/opt/local/bin/gfortran-mp-14 -DGFORTRAN -frecord-marker=4 -fconvert=little-endian -fpic  -O3 -ftree-vectorize -mtune=native  -c ssfunction0.f90
/opt/local/var/macports/build/_opt_svacchanda_SonomaPorts_math_mcmcf90/mcmcf90/work/compwrap/f90/opt/local/bin/gfortran-mp-14 -DGFORTRAN -frecord-marker=4 -fconvert=little-endian -fpic  -O3 -ftree-vectorize -mtune=native  -c checkbounds0.f90
/opt/local/var/macports/build/_opt_svacchanda_SonomaPorts_math_mcmcf90/mcmcf90/work/compwrap/f90/opt/local/bin/gfortran-mp-14 -DGFORTRAN -frecord-marker=4 -fconvert=little-endian -fpic  -O3 -ftree-vectorize -mtune=native  -c ssfunction_er0.f90
/opt/local/var/macports/build/_opt_svacchanda_SonomaPorts_math_mcmcf90/mcmcf90/work/compwrap/f90/opt/local/bin/gfortran-mp-14 -DGFORTRAN -frecord-marker=4 -fconvert=little-endian -fpic  -O3 -ftree-vectorize -mtune=native  -c mcmc_main.F90
/opt/local/var/macports/build/_opt_svacchanda_SonomaPorts_math_mcmcf90/mcmcf90/work/compwrap/f90/opt/local/bin/gfortran-mp-14 -DGFORTRAN -frecord-marker=4 -fconvert=little-endian -fpic  -O3 -ftree-vectorize -mtune=native  -c initialize.F90
/opt/local/var/macports/build/_opt_svacchanda_SonomaPorts_math_mcmcf90/mcmcf90/work/compwrap/f90/opt/local/bin/gfortran-mp-14 -DGFORTRAN -frecord-marker=4 -fconvert=little-endian -fpic  -O3 -ftree-vectorize -mtune=native  -c dump.F90
/opt/local/var/macports/build/_opt_svacchanda_SonomaPorts_math_mcmcf90/mcmcf90/work/compwrap/cc/usr/bin/clang -O2  -c signalqq.c
ar ruv libmcmcrun.a dchud.o dchdd.o  priorfun.o ssfunction0.o checkbounds0.o ssfunction_er0.o mcmc_main.o mcmc.o mcmcinit.o matutils.o mcmcprec.o mcmcrand.o matfiles.o mcmcrun1.o initialize.o dump.o signalqq.o
ar: creating archive libmcmcrun.a
a - dchud.o
a - dchdd.o
a - priorfun.o
a - ssfunction0.o
a - checkbounds0.o
a - ssfunction_er0.o
a - mcmc_main.o
a - mcmc.o
a - mcmcinit.o
a - matutils.o
a - mcmcprec.o
a - mcmcrand.o
a - matfiles.o
a - mcmcrun1.o
a - initialize.o
a - dump.o
a - signalqq.o
ranlib libmcmcrun.a
/opt/local/var/macports/build/_opt_svacchanda_SonomaPorts_math_mcmcf90/mcmcf90/work/compwrap/cc/usr/bin/clang -Os -isysroot/Library/Developer/CommandLineTools/SDKs/MacOSX14.sdk -arch arm64 -dynamiclib -o libmcmcrun.dylib dchud.o dchdd.o  priorfun.o ssfunction0.o checkbounds0.o ssfunction_er0.o mcmc_main.o mcmc.o mcmcinit.o matutils.o mcmcprec.o mcmcrand.o matfiles.o mcmcrun1.o initialize.o dump.o signalqq.o -L/opt/local/lib/libgcc -lgfortran -lopenblas
make: Leaving directory `/opt/local/var/macports/build/_opt_svacchanda_SonomaPorts_math_mcmcf90/mcmcf90/work/mcmcf90-67d6078137b7bdd6ed8ba84440ca99237301fe86'
--->  Staging mcmcf90 into destroot
```